### PR TITLE
Remove duplicate gemspec

### DIFF
--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('aruba')
   s.add_development_dependency('capybara')
   s.add_development_dependency('bundler')
-  s.add_development_dependency('cocaine', '~> 0.3.0')
   s.add_development_dependency('fog')
   s.add_development_dependency('rake')
   s.add_development_dependency('fakeweb')


### PR DESCRIPTION
The cocaine gem is defined in same gemspec file.
The issue occurs error by recent bundler gem.